### PR TITLE
Fix compile bug

### DIFF
--- a/tmate.h
+++ b/tmate.h
@@ -3,6 +3,7 @@
 
 #include <sys/types.h>
 #include <msgpack.h>
+#include <libssh/libssh.h>
 #include <event.h>
 
 #include "tmux.h"
@@ -97,9 +98,6 @@ extern void tmate_replayer_init(struct tmate_replayer *replayer,
 
 
 /* tmate-ssh-client.c */
-
-typedef struct ssh_session_struct* ssh_session;
-typedef struct ssh_channel_struct* ssh_channel;
 
 #define TMATE_ROLE_SERVER 1
 #define TMATE_ROLE_CLIENT 2


### PR DESCRIPTION
In file included from tmate-slave.c:18:
tmate.h:101: error: redefinition of typedef ‘ssh_session’
libssh/include/libssh/libssh.h:115: note: previous declaration of ‘ssh_session’ was here
tmate.h:102: error: redefinition of typedef ‘ssh_channel’
libssh/include/libssh/libssh.h:110: note: previous declaration of ‘ssh_channel’ was here
make: **\* [tmate-slave.o] Error 1
