### PR TITLE
Print ssh port on messages

### DIFF
--- a/tmate-decoder.c
+++ b/tmate-decoder.c
@@ -119,11 +119,17 @@ static void tmate_header(struct tmate_decoder *decoder,
 	if (gethostname(hostname, sizeof(hostname)) < 0)
 		tmate_fatal("cannot get hostname");
 
-	tmate_notify("Remote session read only: ssh ro-%s@%s.%s (clear your screen if you share this)",
-		     tmate_session_token_ro, hostname, TMATE_DOMAIN);
+	tmate_notify("Remote session read only: ssh -p%d ro-%s@%s.%s (clear your screen if you share this)",
+ 				 TMATE_DEFAULT_PORT,
+		     tmate_session_token_ro,
+		     hostname,
+		     TMATE_DOMAIN);
 
-	tmate_notify("Remote session: ssh %s@%s.%s",
-		     tmate_session_token, hostname, TMATE_DOMAIN);
+	tmate_notify("Remote session: ssh -p%d %s@%s.%s",
+ 				 TMATE_DEFAULT_PORT,
+		     tmate_session_token,
+		     hostname,
+		     TMATE_DOMAIN);
 }
 
 extern u_int next_window_pane_id;


### PR DESCRIPTION
When TMATE_DEFAULT_PORT is not ssh standard, the printed message can be confusing, this patch refactor the message string, implementing the "-p" ssh argument.
