### PR TITLE
Fix create_keys for earlier verisons of OpenSSH

### DIFF
--- a/create_keys.sh
+++ b/create_keys.sh
@@ -5,6 +5,9 @@ gen_key() {
   key="keys/ssh_host_${ks}key"
   if [ ! -e "${key}" ] ; then
     ssh-keygen -t ${keytype} -f "${key}" -N '' -E md5
+    if [ $? != 0 ]; then
+       ssh-keygen -t ${keytype} -f "${key}" -N ''
+    fi
     return $?
   fi
 }


### PR DESCRIPTION
Versions of OpenSSH prior to 6.8 (at least) don't support the -E
option to specify the fingerprint hash type.

If ssh-keygen fails, it should be safe to retry without the -E option,
earlier versions have md5 as the default.