### PR TITLE
Added -b to specify IP Address to bind to

### DIFF
--- a/tmate-slave.c
+++ b/tmate-slave.c
@@ -36,6 +36,7 @@ struct tmate_settings _tmate_settings = {
 	.keys_dir        = TMATE_SSH_DEFAULT_KEYS_DIR,
 	.ssh_port        = TMATE_SSH_DEFAULT_PORT,
 	.proxy_hostname  = NULL,
+	.bind_ip	 = NULL,
 	.proxy_port      = TMATE_DEFAULT_PROXY_PORT,
 	.tmate_host      = NULL,
 	.log_level       = LOG_NOTICE,
@@ -101,7 +102,7 @@ void request_server_termination(void)
 
 static void usage(void)
 {
-	fprintf(stderr, "usage: tmate-slave [-h hostname] [-k keys_dir] [-p port] [-x proxy_hostname] [-q proxy_port] [-s] [-v]\n");
+	fprintf(stderr, "usage: tmate-slave [-b ip] [-h hostname] [-k keys_dir] [-p port] [-x proxy_hostname] [-q proxy_port] [-s] [-v]\n");
 }
 
 static char* get_full_hostname(void)
@@ -154,8 +155,11 @@ int main(int argc, char **argv, char **envp)
 {
 	int opt;
 
-	while ((opt = getopt(argc, argv, "h:k:p:x:q:sv")) != -1) {
+	while ((opt = getopt(argc, argv, "b:h:k:p:x:q:sv")) != -1) {
 		switch (opt) {
+		case 'b':
+			tmate_settings->bind_ip = xstrdup(optarg);
+			break;
 		case 'h':
 			tmate_settings->tmate_host = xstrdup(optarg);
 			break;
@@ -188,6 +192,9 @@ int main(int argc, char **argv, char **envp)
 
 	setup_locale();
 
+	if (!tmate_settings->bind_ip)
+		tmate_settings->bind_ip = "0.0.0.0";
+
 	if (!tmate_settings->tmate_host)
 		tmate_settings->tmate_host = get_full_hostname();
 
@@ -211,7 +218,7 @@ int main(int argc, char **argv, char **envp)
 		tmate_fatal("Cannot prepare session in " TMATE_WORKDIR);
 
 	tmate_ssh_server_main(tmate_session,
-			      tmate_settings->keys_dir, tmate_settings->ssh_port);
+			      tmate_settings->keys_dir, tmate_settings->bind_ip, tmate_settings->ssh_port);
 	return 0;
 }
 

--- a/tmate-slave.c
+++ b/tmate-slave.c
@@ -192,9 +192,6 @@ int main(int argc, char **argv, char **envp)
 
 	setup_locale();
 
-	if (!tmate_settings->bind_ip)
-		tmate_settings->bind_ip = "0.0.0.0";
-
 	if (!tmate_settings->tmate_host)
 		tmate_settings->tmate_host = get_full_hostname();
 

--- a/tmate-slave.c
+++ b/tmate-slave.c
@@ -36,7 +36,7 @@ struct tmate_settings _tmate_settings = {
 	.keys_dir        = TMATE_SSH_DEFAULT_KEYS_DIR,
 	.ssh_port        = TMATE_SSH_DEFAULT_PORT,
 	.proxy_hostname  = NULL,
-	.bind_ip	 = NULL,
+	.bind_addr	 = NULL,
 	.proxy_port      = TMATE_DEFAULT_PROXY_PORT,
 	.tmate_host      = NULL,
 	.log_level       = LOG_NOTICE,
@@ -158,7 +158,7 @@ int main(int argc, char **argv, char **envp)
 	while ((opt = getopt(argc, argv, "b:h:k:p:x:q:sv")) != -1) {
 		switch (opt) {
 		case 'b':
-			tmate_settings->bind_ip = xstrdup(optarg);
+			tmate_settings->bind_addr = xstrdup(optarg);
 			break;
 		case 'h':
 			tmate_settings->tmate_host = xstrdup(optarg);
@@ -215,7 +215,7 @@ int main(int argc, char **argv, char **envp)
 		tmate_fatal("Cannot prepare session in " TMATE_WORKDIR);
 
 	tmate_ssh_server_main(tmate_session,
-			      tmate_settings->keys_dir, tmate_settings->bind_ip, tmate_settings->ssh_port);
+			      tmate_settings->keys_dir, tmate_settings->bind_addr, tmate_settings->ssh_port);
 	return 0;
 }
 

--- a/tmate-ssh-server.c
+++ b/tmate-ssh-server.c
@@ -254,7 +254,7 @@ static void ssh_log_function(int priority, const char *function,
 	tmate_info("[%d] [%s] %s", priority, function, buffer);
 }
 
-static ssh_bind prepare_ssh(const char *keys_dir, const char *host, int port)
+static ssh_bind prepare_ssh(const char *keys_dir, const char *bind_addr, int port)
 {
 	ssh_bind bind;
 	char buffer[PATH_MAX];
@@ -266,8 +266,8 @@ static ssh_bind prepare_ssh(const char *keys_dir, const char *host, int port)
 	if (!bind)
 		tmate_fatal("Cannot initialize ssh");
 
-	if (host)
-		ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDADDR, host);
+	if (bind_addr)
+		ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDADDR, bind_addr);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDPORT, &port);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BANNER, TMATE_SSH_BANNER);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_LOG_VERBOSITY, &verbosity);
@@ -281,7 +281,7 @@ static ssh_bind prepare_ssh(const char *keys_dir, const char *host, int port)
 	if (ssh_bind_listen(bind) < 0)
 		tmate_fatal("Error listening to socket: %s\n", ssh_get_error(bind));
 
-	tmate_notice("Accepting connections on %s:%d", (host)?(host):"", port);
+	tmate_notice("Accepting connections on %s:%d", (bind_addr)?(bind_addr):"", port);
 
 	return bind;
 }
@@ -318,7 +318,7 @@ static void handle_sigsegv(__unused int sig)
 
 void tmate_ssh_server_main(struct tmate_session *session,
 			   const char *keys_dir, 
-			   const char *host, int port)
+			   const char *bind_addr, int port)
 {
 	struct tmate_ssh_client *client = &session->ssh_client;
 	ssh_bind bind;
@@ -327,7 +327,7 @@ void tmate_ssh_server_main(struct tmate_session *session,
 	signal(SIGSEGV, handle_sigsegv);
 	signal(SIGCHLD, handle_sigchld);
 
-	bind = prepare_ssh(keys_dir, host, port);
+	bind = prepare_ssh(keys_dir, bind_addr, port);
 
 	for (;;) {
 		client->session = ssh_new();

--- a/tmate-ssh-server.c
+++ b/tmate-ssh-server.c
@@ -266,7 +266,8 @@ static ssh_bind prepare_ssh(const char *keys_dir, const char *host, int port)
 	if (!bind)
 		tmate_fatal("Cannot initialize ssh");
 
-	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDADDR, host);
+	if (host)
+		ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDADDR, host);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDPORT, &port);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BANNER, TMATE_SSH_BANNER);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_LOG_VERBOSITY, &verbosity);
@@ -280,7 +281,7 @@ static ssh_bind prepare_ssh(const char *keys_dir, const char *host, int port)
 	if (ssh_bind_listen(bind) < 0)
 		tmate_fatal("Error listening to socket: %s\n", ssh_get_error(bind));
 
-	tmate_notice("Accepting connections on %s:%d", host, port);
+	tmate_notice("Accepting connections on %s:%d", (host)?(host):"", port);
 
 	return bind;
 }

--- a/tmate-ssh-server.c
+++ b/tmate-ssh-server.c
@@ -254,7 +254,7 @@ static void ssh_log_function(int priority, const char *function,
 	tmate_info("[%d] [%s] %s", priority, function, buffer);
 }
 
-static ssh_bind prepare_ssh(const char *keys_dir, int port)
+static ssh_bind prepare_ssh(const char *keys_dir, const char *host, int port)
 {
 	ssh_bind bind;
 	char buffer[PATH_MAX];
@@ -266,6 +266,7 @@ static ssh_bind prepare_ssh(const char *keys_dir, int port)
 	if (!bind)
 		tmate_fatal("Cannot initialize ssh");
 
+	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDADDR, host);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDPORT, &port);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BANNER, TMATE_SSH_BANNER);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_LOG_VERBOSITY, &verbosity);
@@ -279,7 +280,7 @@ static ssh_bind prepare_ssh(const char *keys_dir, int port)
 	if (ssh_bind_listen(bind) < 0)
 		tmate_fatal("Error listening to socket: %s\n", ssh_get_error(bind));
 
-	tmate_notice("Accepting connections on %d", port);
+	tmate_notice("Accepting connections on %s:%d", host, port);
 
 	return bind;
 }
@@ -315,7 +316,8 @@ static void handle_sigsegv(__unused int sig)
 }
 
 void tmate_ssh_server_main(struct tmate_session *session,
-			   const char *keys_dir, int port)
+			   const char *keys_dir, 
+			   const char *host, int port)
 {
 	struct tmate_ssh_client *client = &session->ssh_client;
 	ssh_bind bind;
@@ -324,7 +326,7 @@ void tmate_ssh_server_main(struct tmate_session *session,
 	signal(SIGSEGV, handle_sigsegv);
 	signal(SIGCHLD, handle_sigchld);
 
-	bind = prepare_ssh(keys_dir, port);
+	bind = prepare_ssh(keys_dir, host, port);
 
 	for (;;) {
 		client->session = ssh_new();

--- a/tmate.h
+++ b/tmate.h
@@ -183,7 +183,7 @@ struct tmate_ssh_client {
 };
 
 extern void tmate_ssh_server_main(struct tmate_session *session,
-				  const char *keys_dir, int port);
+				  const char *keys_dir, const char *host, int port);
 
 /* tmate-slave.c */
 
@@ -209,6 +209,7 @@ struct tmate_settings {
 	const char *proxy_hostname;
 	int proxy_port;
 	const char *tmate_host;
+	const char *bind_ip;
 	int log_level;
 	bool use_syslog;
 };

--- a/tmate.h
+++ b/tmate.h
@@ -209,7 +209,7 @@ struct tmate_settings {
 	const char *proxy_hostname;
 	int proxy_port;
 	const char *tmate_host;
-	const char *bind_ip;
+	const char *bind_addr;
 	int log_level;
 	bool use_syslog;
 };


### PR DESCRIPTION
Currently, tmate is listening on 0.0.0.0:22. I've found it to be really useful to have an option to allow it listening on a specific address while still having the regular SSH daemon listening on some others...