### PR TITLE
Handle return value of nice(3) properly

### DIFF
--- a/tmate-slave.c
+++ b/tmate-slave.c
@@ -393,8 +393,9 @@ static void jail(void)
 		tmate_fatal("Cannot setuid()");
 #endif
 
-	if (nice(1) < 0)
-		tmate_fatal("Cannot nice()");
+	/* this might fail, but it doesn't affect anything
+	   except scheduling priorities, so it is no big deal. */
+	nice(1);
 
 	tmate_info("Dropped priviledges to %s (%d,%d), jailed in %s",
 		   TMATE_JAIL_USER, uid, gid, TMATE_WORKDIR "/jail");


### PR DESCRIPTION
The man page for nice(3) states:

> Upon successful completion, nice() shall return the new nice
> value -{NZERO}. Otherwise, -1 shall be returned, the process'
> nice value shall not be changed, and errno shall be set to
> indicate the error.

i.e., negative values that are not -1 are perfectly valid return codes.
(Admittedly, this is a problem with the design of nice(3), but it's what
we've got to work with.)

This fixes a bug I ran into when tmate-slave process was running at
priority -10, and the `nice(1)` call incremented that to -9.