### PR TITLE
Client disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ The following environment variables are used to configure the server:
 Note that you need to add the *SYS_ADMIN* capability to the container.
 This is needed to create nested containers (namespaces) to secure sessions.
 
+CLI arguments
+-------------
+
+* `-b`: address to bind
+* `-d`: disclaimer to display to client
+* `-h`: tmate hostname
+* `-k`: ssh keys path
+* `-p`: port to bind
+* `-q`: port advertized
+* `-w`: websocket hostname
+* `-z`: websocket port
+* `-x`: use proxy protocol
+* `-v`: log level
+
+For more low-level information please see [tmate-main.c](./tmate-main.c).
+
 License
 --------
 

--- a/tmate-daemon-decoder.c
+++ b/tmate-daemon-decoder.c
@@ -27,6 +27,7 @@ static void tmate_header(struct tmate_session *session,
 			 struct tmate_unpacker *uk)
 {
 	char *ssh_conn_str;
+	char *disclaimer;
 
 	session->client_protocol_version = unpack_int(uk);
 
@@ -56,6 +57,10 @@ static void tmate_header(struct tmate_session *session,
 
 	ssh_conn_str = get_ssh_conn_string(session->session_token_ro);
 	tmate_notify("Note: clear your terminal before sharing readonly access");
+	disclaimer = tmate_settings->disclaimer;
+	if (disclaimer != NULL) {
+		tmate_notify("%s", disclaimer);
+	}
 	tmate_notify("ssh session read only: %s", ssh_conn_str);
 	tmate_set_env("tmate_ssh_ro", ssh_conn_str);
 	free(ssh_conn_str);

--- a/tmate-main.c
+++ b/tmate-main.c
@@ -102,10 +102,13 @@ int main(int argc, char **argv, char **envp)
 {
 	int opt;
 
-	while ((opt = getopt(argc, argv, "b:h:k:p:q:w:z:xv")) != -1) {
+	while ((opt = getopt(argc, argv, "b:d:h:k:p:q:w:z:xv")) != -1) {
 		switch (opt) {
 		case 'b':
 			tmate_settings->bind_addr = xstrdup(optarg);
+			break;
+		case 'd':
+			tmate_settings->disclaimer = xstrdup(optarg);
 			break;
 		case 'h':
 			tmate_settings->tmate_host = xstrdup(optarg);

--- a/tmate.h
+++ b/tmate.h
@@ -193,6 +193,7 @@ extern void tmate_ssh_server_main(struct tmate_session *session,
 
 struct tmate_settings {
 	const char *keys_dir;
+	const char *disclaimer;
 	const char *authorized_keys_path;
 	int ssh_port;
 	int ssh_port_advertized;


### PR DESCRIPTION
Hi,

I added a small feature to display a custom message/disclaimer when a user creates a tmate session.
When server is start with a `-d` flag and an associated string, the disclaimer is display just after the `note:`.
If no disclaimer is declared no print will be done.

#### Note
Escape characters such as `\n` will be print in the disclaimer and won't produce a line feed.

### e.g.
#### server:
```
$ nocorrect docker run --rm -v /tmp/tma:/root/ -p 2200:2200 -e SSH_KEYS_PATH=/root --cap-add=SYS_ADMIN antonin/tmate-ssh-server -d "    -> Hello and Welcome to tmate \! <-"
sh: out of range
sh: out of range
Loading key /root/ssh_host_ed25519_key
Accepting connections on :2200
[LtxQ...] Spawning daemon ip=172.17.0.1
[LtxQ...] tmate version=2.4.0, protocol=6
[LtxQ...] sysname=Linux machine=x86_64 release=5.4.111 version=#1-NixOS SMP Sat Apr 10 11:34:32 UTC 2021 nodename=rilakkuma
```
#### client:
```
Tip: if you wish to use tmate only for remote access, run: tmate -F                                                                [0/0]
To see the following messages again, run in a tmate session: tmate show-messages
Press <q> or <ctrl-c> to continue
---------------------------------------------------------------------
Connecting to localhost...
Note: clear your terminal before sharing readonly access
    -> Hello and Welcome to tmate ! <-
ssh session read only: ssh -p2200 ro-PVWBWbhUQMgrTsEKJyzzM3dXy@35dea2f45857
ssh session: ssh -p2200 LtxQZV98ybg2YVwAxftcFhpp8@35dea2f45857
```