### PR TITLE
Ebardie/authorized keys only

### DIFF
--- a/tmate-daemon-decoder.c
+++ b/tmate-daemon-decoder.c
@@ -6,6 +6,10 @@
 
 char *tmate_left_status, *tmate_right_status;
 
+#define AUTHORIZED_KEYS_ONLY_ERROR_MSG_1 "Server requires authorized_keys but none are given."
+#define AUTHORIZED_KEYS_ONLY_ERROR_MSG_2 "Use '-a FILENAME' to specify an authorized_keys file."
+#define AUTHORIZED_KEYS_ONLY_ERROR_MSG_3 "Press <Ctrl-c><Ctrl-d> to exit."
+
 static void tmate_ready(struct tmate_session *session,
 			__unused struct tmate_unpacker *uk)
 {
@@ -19,6 +23,16 @@ static void tmate_ready(struct tmate_session *session,
 	if (session->authorized_keys) {
 		int count = get_num_authorized_keys(session->authorized_keys);
 		tmate_info("Restricting ssh access, num_keys=%d", count);
+	} else if (tmate_settings->authorized_keys_only) {
+		/* Inform the user that this connexion isn't happening,
+		 * and what to do about it.
+		 */
+
+		tmate_notify(AUTHORIZED_KEYS_ONLY_ERROR_MSG_1);
+		tmate_notify(AUTHORIZED_KEYS_ONLY_ERROR_MSG_2);
+		tmate_notify(AUTHORIZED_KEYS_ONLY_ERROR_MSG_3);
+		tmate_notify("");
+		server_send_exit();
 	}
 	server_add_accept(0);
 }

--- a/tmate-main.c
+++ b/tmate-main.c
@@ -33,6 +33,7 @@ struct tmate_settings _tmate_settings = {
 	.tmate_host      	= NULL,
 	.log_level      	= LOG_INFO,
 	.use_proxy_protocol	= false,
+	.authorized_keys_only	= false,
 };
 
 struct tmate_settings *tmate_settings = &_tmate_settings;
@@ -49,7 +50,7 @@ void request_server_termination(void)
 
 static void usage(void)
 {
-	fprintf(stderr, "usage: tmate-ssh-server [-b ip] [-h hostname] [-k keys_dir] [-p listen_port] [-q ssh_port_advertized] [-w websocket_hostname] [-z websocket_port] [-x] [-v]\n");
+	fprintf(stderr, "usage: tmate-ssh-server [-A] [-b ip] [-h hostname] [-k keys_dir] [-p listen_port] [-q ssh_port_advertized] [-w websocket_hostname] [-z websocket_port] [-x] [-v]\n");
 }
 
 static char* get_full_hostname(void)
@@ -102,8 +103,11 @@ int main(int argc, char **argv, char **envp)
 {
 	int opt;
 
-	while ((opt = getopt(argc, argv, "b:h:k:p:q:w:z:xv")) != -1) {
+	while ((opt = getopt(argc, argv, "Ab:h:k:p:q:w:z:xv")) != -1) {
 		switch (opt) {
+		case 'A':
+			tmate_settings->authorized_keys_only = true;
+			break;
 		case 'b':
 			tmate_settings->bind_addr = xstrdup(optarg);
 			break;

--- a/tmate.h
+++ b/tmate.h
@@ -194,6 +194,7 @@ extern void tmate_ssh_server_main(struct tmate_session *session,
 struct tmate_settings {
 	const char *keys_dir;
 	const char *authorized_keys_path;
+	bool authorized_keys_only;
 	int ssh_port;
 	int ssh_port_advertized;
 	const char *websocket_hostname;

--- a/tmux.h
+++ b/tmux.h
@@ -1941,6 +1941,10 @@ int	 server_start(struct event_base *, int, char *);
 void	 server_update_socket(void);
 void	 server_add_accept(int);
 
+#ifdef TMATE
+void    server_send_exit(void);
+#endif
+
 /* server-client.c */
 void	 server_client_set_key_table(struct client *, const char *);
 const char *server_client_get_key_table(struct client *);


### PR DESCRIPTION
Add a command line flag (`-A`) to specify that sessions must use the authorized keys mechanism.

Without this, users can create unsecured sessions, something the tmate server admin may not wish to allow.