### PR TITLE
Fix docker image SEGFAULT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.17.4 AS build
 
-RUN apk add --no-cache msgpack-c ncurses-libs libevent openssl zlib
-
 RUN apk add --no-cache \
 	autoconf \
 	automake \
@@ -9,21 +7,25 @@ RUN apk add --no-cache \
 	g++ \
 	gcc \
 	git \
+	libevent \
 	libevent-dev \
+	libssh-dev \
 	linux-headers \
 	make \
+	msgpack-c \
 	msgpack-c-dev \
 	ncurses-dev \
+	ncurses-libs \
+	openssl \
 	openssl-dev \
+	zlib \
 	zlib-dev
 
-RUN apk add --no-cache libssh-dev
 
-RUN mkdir -p /src/tmate-ssh-server
+WORKDIR /src/tmate-ssh-server
 COPY . /src/tmate-ssh-server
 
 RUN set -ex; \
-	cd /src/tmate-ssh-server; \
 	./autogen.sh; \
 	./configure --prefix=/usr CFLAGS="-D_GNU_SOURCE"; \
 	make -j "$(nproc)"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS build
+FROM alpine:3.17.4 AS build
 
 RUN apk add --no-cache msgpack-c ncurses-libs libevent openssl zlib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16 AS build
 
-RUN apk add --no-cache msgpack-c ncurses-libs libevent libexecinfo openssl zlib
+RUN apk add --no-cache msgpack-c ncurses-libs libevent openssl zlib
 
 RUN apk add --no-cache \
 	autoconf \
@@ -10,7 +10,6 @@ RUN apk add --no-cache \
 	gcc \
 	git \
 	libevent-dev \
-	libexecinfo-dev \
 	linux-headers \
 	make \
 	msgpack-c-dev \
@@ -37,7 +36,6 @@ RUN apk add --no-cache \
 	bash \
 	gdb \
 	libevent \
-	libexecinfo \
 	libssh \
 	msgpack-c \
 	ncurses-libs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.4 AS build
+FROM alpine:3.17.8 AS build
 
 RUN apk add --no-cache \
 	autoconf \
@@ -32,7 +32,7 @@ RUN set -ex; \
 	make install
 
 ### Minimal run-time image
-FROM alpine:3.16
+FROM alpine:3.17.8
 
 RUN apk add --no-cache \
 	bash \


### PR DESCRIPTION
This PR is mostly related to the `Dockerfile`:

- get rid of `libexecinfo`
- bump alpine version to 3.17.4 (last version which had `libexecinfo` is `3.16`
- cleanup `Dockerfile`

Fixes #104 