### PR TITLE
Remove libexecinfo from installed library in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk add --no-cache \
 	gcc \
 	git \
 	libevent-dev \
-	libexecinfo-dev \
 	linux-headers \
 	make \
 	msgpack-c-dev \
@@ -37,7 +36,6 @@ RUN apk add --no-cache \
 	bash \
 	gdb \
 	libevent \
-	libexecinfo \
 	libssh \
 	msgpack-c \
 	ncurses-libs \


### PR DESCRIPTION
This PR removes the libexecinfo from installed library.
The library provided on Alpine is known to have a bug and the `tmate-ssh-server` program exits with segmentation fault due to the library.
